### PR TITLE
[NO-ISSUE] Render 슬립 방지를 위한 자동 ping 워크플로우 구성

### DIFF
--- a/.github/workflows/ping.yml
+++ b/.github/workflows/ping.yml
@@ -1,0 +1,15 @@
+name: Scheduled Ping to Render App
+
+on:
+  schedule:
+    - cron: '*/15 * * * *' # 매 15분마다 실행
+  workflow_dispatch: # 수동 실행
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: scheduled ping
+        uses: sisodiya2421/pinger@v3
+        with:
+          url: 'https://ilta-api.onrender.com'


### PR DESCRIPTION
## 📝작업 내용
### Render 슬립 방지를 위한 자동 ping 워크플로우 구성
우리가 쓰는 Render 무료 버전은, 일정 시간이 지나면 슬립으로 들어갑니다.
따라서, GitHub Actions 기반 Scheduled Ping으로 Render cold start 임시 대응합니다.

## PR 유형

- [x] 새로운 기능 추가

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
