### PR TITLE
[NO-ISSUE] Render 슬립 방지 자동 ping 주기 단축

### DIFF
--- a/.github/workflows/ping.yml
+++ b/.github/workflows/ping.yml
@@ -2,7 +2,7 @@ name: Scheduled Ping to Render App
 
 on:
   schedule:
-    - cron: '*/15 * * * *' # 매 15분마다 실행
+    - cron: '*/5 * * * *' # 매 5분마다 실행
   workflow_dispatch: # 수동 실행
 
 jobs:


### PR DESCRIPTION
## 📝작업 내용
Render 슬립 방지 자동 ping 주기를 15분에서 5분으로 단축했습니다.

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
