### PR TITLE
[AMT-31] OpenFeign 기반 Supabase 이미지 업로드 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,16 @@ repositories {
     mavenCentral()
 }
 
+ext {
+    set('springCloudVersion', "2025.0.0")
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:2025.0.0"
+    }
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
@@ -52,6 +62,8 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+    // openfeign
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ll/ilta/IltaApplication.java
+++ b/src/main/java/com/ll/ilta/IltaApplication.java
@@ -2,9 +2,10 @@ package com.ll.ilta;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-
+@EnableFeignClients
 @EnableJpaAuditing
 @SpringBootApplication
 public class IltaApplication {

--- a/src/main/java/com/ll/ilta/domain/image/client/SupabaseFeignClient.java
+++ b/src/main/java/com/ll/ilta/domain/image/client/SupabaseFeignClient.java
@@ -17,12 +17,12 @@ import org.springframework.web.multipart.MultipartFile;
 public interface SupabaseFeignClient {
 
     @PostMapping(
-        value = "/storage/v1/object/{bucket}/upload",
+        value = "/storage/v1/object/{bucket}/{path}",
         consumes = MediaType.MULTIPART_FORM_DATA_VALUE
     )
     void uploadImage(
         @PathVariable("bucket") String bucket,
-        @RequestPart("file") MultipartFile file,
-        @RequestParam("name") String filename
+        @PathVariable("path") String path,
+        @RequestPart("file") MultipartFile file
     );
 }

--- a/src/main/java/com/ll/ilta/domain/image/client/SupabaseFeignClient.java
+++ b/src/main/java/com/ll/ilta/domain/image/client/SupabaseFeignClient.java
@@ -1,0 +1,28 @@
+package com.ll.ilta.domain.image.client;
+
+import com.ll.ilta.global.config.FeignConfig;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.multipart.MultipartFile;
+
+@FeignClient(
+    name = "SupabaseFeignClient",
+    url = "${supabase.url}",
+    configuration = FeignConfig.class
+)
+public interface SupabaseFeignClient {
+
+    @PostMapping(
+        value = "/storage/v1/object/{bucket}/upload",
+        consumes = MediaType.MULTIPART_FORM_DATA_VALUE
+    )
+    void uploadImage(
+        @PathVariable("bucket") String bucket,
+        @RequestPart("file") MultipartFile file,
+        @RequestParam("name") String filename
+    );
+}

--- a/src/main/java/com/ll/ilta/domain/image/controller/ImageV1Controller.java
+++ b/src/main/java/com/ll/ilta/domain/image/controller/ImageV1Controller.java
@@ -17,7 +17,8 @@ public class ImageV1Controller {
 
     @PostMapping("/upload")
     public ResponseEntity<?> upload(@RequestParam("file") MultipartFile file) { // TODO: ResponeDto 구현 필요
-        imageUploadService.uploadImage(file);
+        Long userId = 8L; // TODO: 인증 구현 후 실제 로그인한 유저 ID로 변경
+        imageUploadService.uploadImage(userId, file);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/ll/ilta/domain/image/controller/ImageV1Controller.java
+++ b/src/main/java/com/ll/ilta/domain/image/controller/ImageV1Controller.java
@@ -9,9 +9,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-@RestController
-@RequiredArgsConstructor
 @RequestMapping("/api/v1/image")
+@RequiredArgsConstructor
+@RestController
 public class ImageV1Controller {
     private final ImageUploadService imageUploadService;
 

--- a/src/main/java/com/ll/ilta/domain/image/controller/ImageV1Controller.java
+++ b/src/main/java/com/ll/ilta/domain/image/controller/ImageV1Controller.java
@@ -1,0 +1,23 @@
+package com.ll.ilta.domain.image.controller;
+
+import com.ll.ilta.domain.image.service.ImageUploadService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/image")
+public class ImageV1Controller {
+    private final ImageUploadService imageUploadService;
+
+    @PostMapping("/upload")
+    public ResponseEntity<?> upload(@RequestParam("file") MultipartFile file) { // TODO: ResponeDto 구현 필요
+        imageUploadService.uploadImage(file);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/ll/ilta/domain/image/dto/UploadResponseDto.java
+++ b/src/main/java/com/ll/ilta/domain/image/dto/UploadResponseDto.java
@@ -1,0 +1,5 @@
+package com.ll.ilta.domain.image.dto;
+
+public class UploadResponseDto {
+
+}

--- a/src/main/java/com/ll/ilta/domain/image/dto/UploadResponseDto.java
+++ b/src/main/java/com/ll/ilta/domain/image/dto/UploadResponseDto.java
@@ -1,5 +1,0 @@
-package com.ll.ilta.domain.image.dto;
-
-public class UploadResponseDto {
-
-}

--- a/src/main/java/com/ll/ilta/domain/image/service/ImageUploadService.java
+++ b/src/main/java/com/ll/ilta/domain/image/service/ImageUploadService.java
@@ -1,0 +1,25 @@
+package com.ll.ilta.domain.image.service;
+
+import com.ll.ilta.domain.image.client.SupabaseFeignClient;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class ImageUploadService {
+
+    private final SupabaseFeignClient supabaseFeignClient;
+
+    @Value("${supabase.bucket}")
+    private String bucket;
+
+    public void uploadImage(MultipartFile file) {
+        String filename = URLEncoder.encode(file.getOriginalFilename(), StandardCharsets.UTF_8);
+
+        supabaseFeignClient.uploadImage(bucket, file, filename);
+    }
+}

--- a/src/main/java/com/ll/ilta/domain/image/service/ImageUploadService.java
+++ b/src/main/java/com/ll/ilta/domain/image/service/ImageUploadService.java
@@ -1,8 +1,7 @@
 package com.ll.ilta.domain.image.service;
 
 import com.ll.ilta.domain.image.client.SupabaseFeignClient;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -17,9 +16,15 @@ public class ImageUploadService {
     @Value("${supabase.bucket}")
     private String bucket;
 
-    public void uploadImage(MultipartFile file) {
-        String filename = URLEncoder.encode(file.getOriginalFilename(), StandardCharsets.UTF_8);
+    public void uploadImage(Long userId, MultipartFile file) {
 
-        supabaseFeignClient.uploadImage(bucket, file, filename);
+        String extension = "";
+        if (file.getOriginalFilename() != null && file.getOriginalFilename().contains(".")) {
+            extension = file.getOriginalFilename().substring(file.getOriginalFilename().lastIndexOf("."));
+        }
+        String uniqueFilename = UUID.randomUUID().toString() + extension;
+        String path = userId + "/" + uniqueFilename;
+        supabaseFeignClient.uploadImage(bucket, path, file);
+
     }
 }

--- a/src/main/java/com/ll/ilta/domain/image/service/ImageUploadService.java
+++ b/src/main/java/com/ll/ilta/domain/image/service/ImageUploadService.java
@@ -7,8 +7,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-@Service
 @RequiredArgsConstructor
+@Service
 public class ImageUploadService {
 
     private final SupabaseFeignClient supabaseFeignClient;

--- a/src/main/java/com/ll/ilta/global/config/FeignConfig.java
+++ b/src/main/java/com/ll/ilta/global/config/FeignConfig.java
@@ -1,0 +1,21 @@
+package com.ll.ilta.global.config;
+
+import feign.RequestInterceptor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FeignConfig {
+
+    @Value("${supabase.secret-key}")
+    private String secretKey;
+
+    @Bean
+    public RequestInterceptor requestInterceptor() {
+        return requestTemplate -> {
+            requestTemplate.header("apikey", secretKey);
+            requestTemplate.header("Authorization", "Bearer " + secretKey);
+        };
+    }
+}

--- a/src/main/java/com/ll/ilta/global/config/SecurityConfig.java
+++ b/src/main/java/com/ll/ilta/global/config/SecurityConfig.java
@@ -41,6 +41,7 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                 .requestMatchers("/api/v1/member/login").permitAll() // 로그인은 모두 허용
+                .requestMatchers("/api/v1/image/upload").permitAll() // TODO: JWT 검사 제외로 임시 방편, 추후 제거해야 함
                 .anyRequest().authenticated()
             )
             .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/ll/ilta/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ll/ilta/global/security/JwtAuthenticationFilter.java
@@ -26,8 +26,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         FilterChain filterChain) throws ServletException, IOException {
 
         String path = request.getRequestURI();
-        // 로그인 경로 및 인증 안 필요한 경로는 토큰 검사 안 함
-        if (path.equals("/api/v1/member/login") || path.equals("/api/v1/member/register")) {
+        // 로그인 및 인증이 필요하지 않은 경로는 JWT 토큰 검사에서 제외
+        if (path.equals("/api/v1/member/login")
+            || path.equals("/api/v1/member/register")
+            || path.equals("/api/v1/image/upload")) { // TODO: 이미지 업로드 JWT 검사에 추가 예정
             filterChain.doFilter(request, response);
             return;
         }

--- a/src/main/java/com/ll/ilta/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ll/ilta/global/security/JwtAuthenticationFilter.java
@@ -26,10 +26,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         FilterChain filterChain) throws ServletException, IOException {
 
         String path = request.getRequestURI();
-        // 로그인 및 인증이 필요하지 않은 경로는 JWT 토큰 검사에서 제외
+        // 로그인 경로 및 인증 안 필요한 경로는 토큰 검사 안 함
         if (path.equals("/api/v1/member/login")
             || path.equals("/api/v1/member/register")
-            || path.equals("/api/v1/image/upload")) { // TODO: 이미지 업로드 JWT 검사에 추가 예정
+            || path.equals("/api/v1/image/upload")) { // TODO: 이미지 업로드 JWT 포함 후 삭제 예정
             filterChain.doFilter(request, response);
             return;
         }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -23,3 +23,7 @@ spring:
 jwt:
   secret: ${JWT_SECRET}
   expiration: 3600000
+
+logging:
+  level:
+    org.springframework.cloud.openfeign: DEBUG

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,12 @@ spring:
   profiles:
     active: dev         # 배포 환경 시 prod, 개발 환경 시 dev 설정
     include: secret
+  servlet:
+    multipart:
+      enabled: true
+      max-file-size: 5MB
+      max-request-size: 5MB
+
 
   jpa:
     hibernate:
@@ -21,3 +27,8 @@ logging:
     org.hibernate.SQL: OFF
     org.hibernate.orm.jdbc.bind: OFF
     org.springframework.transaction.interceptor: OFF
+
+supabase:
+  url: ${SUPABASE_URL}
+  secret-key: ${SUPABASE_SECRET_KEY}
+  bucket: "ilta-images"


### PR DESCRIPTION
## 📝작업 내용
### OpenFeign 기반 Supabase 이미지 업로드 API 구현
- Supabase 이미지 업로드 API 구현
- 동일 파일명 업로드 시 덮어쓰기 버그 해결 (UUID 기반 경로)
- _테스트 목적의 임시 조치로_, JWT 인증 필터 예외 처리 및 `userId = 8` 상수로 **임시 방편**

## 스크린샷
<img width="782" height="354" alt="image" src="https://github.com/user-attachments/assets/33d263de-f2fa-4d05-8e5c-9ae6b416fed4" />

## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
