### PR TITLE
[AMT-89] 날짜 자동 생성을 위한 BaseEntity 구현 및 서울 타임존 적용

### DIFF
--- a/src/main/java/com/ll/ilta/domain/concept/entity/Concept.java
+++ b/src/main/java/com/ll/ilta/domain/concept/entity/Concept.java
@@ -24,7 +24,7 @@ public class Concept {
     @Column(columnDefinition = "text")
     private String description;
 
-    @Builder
+    @Builder(access = AccessLevel.PRIVATE)
     private Concept(Long id, String name, String description) {
         this.id = id;
         this.name = name;

--- a/src/main/java/com/ll/ilta/domain/favorite/entity/Favorite.java
+++ b/src/main/java/com/ll/ilta/domain/favorite/entity/Favorite.java
@@ -2,9 +2,8 @@ package com.ll.ilta.domain.favorite.entity;
 
 import com.ll.ilta.domain.member.v1.entity.Member;
 import com.ll.ilta.domain.problem.entity.Problem;
-import jakarta.persistence.Column;
+import com.ll.ilta.global.jpa.BaseTimeEntity;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -12,18 +11,16 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EntityListeners(AuditingEntityListener.class)
 @Entity
-public class Favorite {
+public class Favorite extends BaseTimeEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -36,14 +33,13 @@ public class Favorite {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    @CreatedDate
-    @Column(updatable = false)
-    private LocalDateTime createdAt;
+    @Builder(access = AccessLevel.PRIVATE)
+    private Favorite(Problem problem, Member member) {
+        this.problem = problem;
+        this.member = member;
+    }
 
     public static Favorite of(Problem problem, Member member) {
-        Favorite favorite = new Favorite();
-        favorite.problem = problem;
-        favorite.member = member;
-        return favorite;
+        return Favorite.builder().problem(problem).member(member).build();
     }
 }

--- a/src/main/java/com/ll/ilta/domain/image/entity/Image.java
+++ b/src/main/java/com/ll/ilta/domain/image/entity/Image.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -26,12 +27,13 @@ public class Image {
     @JoinColumn(name = "problem_id", nullable = false, unique = true)
     private Problem problem;
 
-    public Image(String imageUrl, Problem problem) {
+    @Builder(access = AccessLevel.PRIVATE)
+    private Image(String imageUrl, Problem problem) {
         this.imageUrl = imageUrl;
         this.problem = problem;
     }
 
     public static Image of(String imageUrl, Problem problem) {
-        return new Image(imageUrl, problem);
+        return Image.builder().imageUrl(imageUrl).problem(problem).build();
     }
 }

--- a/src/main/java/com/ll/ilta/domain/problem/entity/Problem.java
+++ b/src/main/java/com/ll/ilta/domain/problem/entity/Problem.java
@@ -1,28 +1,23 @@
 package com.ll.ilta.domain.problem.entity;
 
 import com.ll.ilta.domain.member.v1.entity.Member;
-import jakarta.persistence.Column;
+import com.ll.ilta.global.jpa.BaseEntity;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EntityListeners(AuditingEntityListener.class)
 @Entity
-public class Problem {
+public class Problem extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -32,16 +27,12 @@ public class Problem {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    @CreatedDate
-    @Column(updatable = false)
-    private LocalDateTime createdAt;
-
-    @LastModifiedDate
-    private LocalDateTime updatedAt;
+    @Builder(access = AccessLevel.PRIVATE)
+    private Problem(Member member) {
+        this.member = member;
+    }
 
     public static Problem from(Member member) {
-        Problem problem = new Problem();
-        problem.member = member;
-        return problem;
+        return Problem.builder().member(member).build();
     }
 }

--- a/src/main/java/com/ll/ilta/domain/problem/entity/ProblemConcept.java
+++ b/src/main/java/com/ll/ilta/domain/problem/entity/ProblemConcept.java
@@ -30,7 +30,7 @@ public class ProblemConcept {
     @JoinColumn(name = "concept_id", nullable = false)
     private Concept concept;
 
-    @Builder
+    @Builder(access = AccessLevel.PRIVATE)
     private ProblemConcept(Problem problem, Concept concept) {
         this.problem = problem;
         this.concept = concept;

--- a/src/main/java/com/ll/ilta/domain/problem/entity/ProblemResult.java
+++ b/src/main/java/com/ll/ilta/domain/problem/entity/ProblemResult.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -33,12 +34,16 @@ public class ProblemResult {
     @JoinColumn(name = "problem_id", nullable = false, unique = true)
     private Problem problem;
 
+    @Builder(access = AccessLevel.PRIVATE)
+    private ProblemResult(String ocrResult, String llmResult, Boolean status, Problem problem) {
+        this.ocrResult = ocrResult;
+        this.llmResult = llmResult;
+        this.status = status;
+        this.problem = problem;
+    }
+
     public static ProblemResult of(String ocrResult, String llmResult, Boolean status, Problem problem) {
-        ProblemResult result = new ProblemResult();
-        result.ocrResult = ocrResult;
-        result.llmResult = llmResult;
-        result.status = status;
-        result.problem = problem;
-        return result;
+        return ProblemResult.builder().ocrResult(ocrResult).llmResult(llmResult).status(status).problem(problem)
+            .build();
     }
 }

--- a/src/main/java/com/ll/ilta/global/jpa/BaseTimeEntity.java
+++ b/src/main/java/com/ll/ilta/global/jpa/BaseTimeEntity.java
@@ -1,17 +1,19 @@
 package com.ll.ilta.global.jpa;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
 import lombok.Getter;
-import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
-public abstract class BaseEntity extends BaseTimeEntity {
+public abstract class BaseTimeEntity {
 
-    @LastModifiedDate
-    private LocalDateTime updatedAt;
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,7 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
         format_sql: false
+        jdbc.time_zone: Asia/Seoul
 
 logging:
   level:


### PR DESCRIPTION
## 📝작업 내용
### 날짜 자동 생성을 위한 BaseEntity 구현 및 서울 타임존 적용

#### BaseEntity 날짜 자동 생성
- BaseTimeEntity: 생성일(createdAt)만 자동 관리
- BaseEntity: 생성일 + 수정일(updatedAt) 자동 관리 (BaseTimeEntity 상속)

#### Entity 생성자 통일
- 기본 생성자 protected 지정 (JPA용)
- 빌더 생성자 private 지정, 외부 인스턴스 생성은 of() 팩토리 메서드로 통일

#### 타임스탬프 서울 시간 설정 문제 해결
- application.yml에 서울 타임존 설정 추가 (spring.jackson.time-zone=Asia/Seoul)
- DB에서 `SHOW TIME ZONE;` 명령어 실행 결과,
  <img width="171" height="49" alt="image" src="https://github.com/user-attachments/assets/6cf6b597-055c-412a-a57c-bb69b1ddf307" />

## ✅ 주요 변경 사항

## 스크린샷 (선택)

## PR 유형

- [x] 새로운 기능 추가
- [x] 버그 수정

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
