### PR TITLE
[AMT-90] Concept description 저장 누락 및 AiResponseDto id null 반환 문제 수정

### DIFF
--- a/src/main/java/com/ll/ilta/domain/concept/dto/ConceptDto.java
+++ b/src/main/java/com/ll/ilta/domain/concept/dto/ConceptDto.java
@@ -1,6 +1,6 @@
-package com.ll.ilta.domain.problem.dto;
+package com.ll.ilta.domain.concept.dto;
 
-import com.ll.ilta.domain.concept.entity.Concept;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
@@ -9,16 +9,13 @@ public class ConceptDto {
     private final Long id;
     private final String name;
 
+    @Builder
     private ConceptDto(Long id, String name) {
         this.id = id;
         this.name = name;
     }
 
     public static ConceptDto of(Long id, String name) {
-        return new ConceptDto(id, name);
-    }
-
-    public Concept toEntity() {
-        return Concept.of(id, name);
+        return ConceptDto.builder().id(id).name(name).build();
     }
 }

--- a/src/main/java/com/ll/ilta/domain/concept/dto/ConceptResponseDto.java
+++ b/src/main/java/com/ll/ilta/domain/concept/dto/ConceptResponseDto.java
@@ -1,6 +1,7 @@
 package com.ll.ilta.domain.concept.dto;
 
 import com.ll.ilta.domain.concept.entity.Concept;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
@@ -10,6 +11,7 @@ public class ConceptResponseDto {
     private final String name;
     private final String description;
 
+    @Builder
     private ConceptResponseDto(Long id, String name, String description) {
         this.id = id;
         this.name = name;
@@ -17,10 +19,7 @@ public class ConceptResponseDto {
     }
 
     public static ConceptResponseDto from(Concept concept) {
-        return new ConceptResponseDto(
-            concept.getId(),
-            concept.getName(),
-            concept.getDescription()
-        );
+        return ConceptResponseDto.builder().id(concept.getId()).name(concept.getName())
+            .description(concept.getDescription()).build();
     }
 }

--- a/src/main/java/com/ll/ilta/domain/concept/entity/Concept.java
+++ b/src/main/java/com/ll/ilta/domain/concept/entity/Concept.java
@@ -31,7 +31,7 @@ public class Concept {
         this.description = description;
     }
 
-    public static Concept of(Long id, String name) {
-        return Concept.builder().id(id).name(name).build();
+    public static Concept of(String name, String description) {
+        return Concept.builder().name(name).description(description).build();
     }
 }

--- a/src/main/java/com/ll/ilta/domain/favorite/dto/FavoriteResponseDto.java
+++ b/src/main/java/com/ll/ilta/domain/favorite/dto/FavoriteResponseDto.java
@@ -1,9 +1,10 @@
 package com.ll.ilta.domain.favorite.dto;
 
-import com.ll.ilta.domain.problem.dto.ConceptDto;
+import com.ll.ilta.domain.concept.dto.ConceptDto;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
@@ -17,8 +18,9 @@ public class FavoriteResponseDto {
     private final String llmResult;
     private final LocalDateTime createdAt;
 
-    private FavoriteResponseDto(Long id, Long problemId, String imageUrl, List<ConceptDto> concepts,
-        String ocrResult, String llmResult, LocalDateTime createdAt) {
+    @Builder
+    private FavoriteResponseDto(Long id, Long problemId, String imageUrl, List<ConceptDto> concepts, String ocrResult,
+        String llmResult, LocalDateTime createdAt) {
         this.id = id;
         this.problemId = problemId;
         this.imageUrl = imageUrl;
@@ -30,6 +32,7 @@ public class FavoriteResponseDto {
 
     public static FavoriteResponseDto of(Long id, Long problemId, String imageUrl, List<ConceptDto> concepts,
         String ocrResult, String llmResult, LocalDateTime createdAt) {
-        return new FavoriteResponseDto(id, problemId, imageUrl, concepts, ocrResult, llmResult, createdAt);
+        return FavoriteResponseDto.builder().id(id).problemId(problemId).imageUrl(imageUrl).concepts(concepts)
+            .ocrResult(ocrResult).llmResult(llmResult).createdAt(createdAt).build();
     }
 }

--- a/src/main/java/com/ll/ilta/domain/favorite/dto/FavoriteToggleResponseDto.java
+++ b/src/main/java/com/ll/ilta/domain/favorite/dto/FavoriteToggleResponseDto.java
@@ -1,12 +1,19 @@
 package com.ll.ilta.domain.favorite.dto;
 
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 public class FavoriteToggleResponseDto {
+
     private final boolean isFavorited;
 
-    public FavoriteToggleResponseDto(boolean isFavorited) {
+    @Builder
+    private FavoriteToggleResponseDto(boolean isFavorited) {
         this.isFavorited = isFavorited;
+    }
+
+    public static FavoriteToggleResponseDto of(boolean isFavorited) {
+        return FavoriteToggleResponseDto.builder().isFavorited(isFavorited).build();
     }
 }

--- a/src/main/java/com/ll/ilta/domain/favorite/service/FavoriteService.java
+++ b/src/main/java/com/ll/ilta/domain/favorite/service/FavoriteService.java
@@ -62,7 +62,7 @@ public class FavoriteService {
 
         if (existing.isPresent()) {
             favoriteRepository.delete(existing.get());
-            return new FavoriteToggleResponseDto(false);
+            return FavoriteToggleResponseDto.of(false);
         } else {
             Problem problem = problemRepository.findById(problemId)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_PROBLEM));
@@ -70,7 +70,7 @@ public class FavoriteService {
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_MEMBER));
 
             favoriteRepository.save(Favorite.of(problem, member));
-            return new FavoriteToggleResponseDto(true);
+            return FavoriteToggleResponseDto.of(true);
         }
 
     }

--- a/src/main/java/com/ll/ilta/domain/image/dto/AiResponseDto.java
+++ b/src/main/java/com/ll/ilta/domain/image/dto/AiResponseDto.java
@@ -1,29 +1,31 @@
 package com.ll.ilta.domain.image.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.ll.ilta.domain.problem.dto.ConceptDto;
+import com.ll.ilta.domain.concept.entity.Concept;
 import java.util.List;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 public class AiResponseDto {
 
-    @JsonProperty("ocr_text")
+    @JsonProperty("summary")
     private final String ocrResult;
 
     @JsonProperty("explanation")
     private final String llmResult;
 
     @JsonProperty("concept_tags")
-    private final List<ConceptDto> conceptTags;
+    private final List<Concept> conceptTags;
 
-    private AiResponseDto(String ocrResult, String llmResult, List<ConceptDto> conceptTags) {
+    @Builder
+    private AiResponseDto(String ocrResult, String llmResult, List<Concept> conceptTags) {
         this.ocrResult = ocrResult;
         this.llmResult = llmResult;
         this.conceptTags = conceptTags;
     }
 
-    public static AiResponseDto of(String ocrResult, String llmResult, List<ConceptDto> concepts) {
-        return new AiResponseDto(ocrResult, llmResult, concepts);
+    public static AiResponseDto of(String ocrResult, String llmResult, List<Concept> conceptTags) {
+        return AiResponseDto.builder().ocrResult(ocrResult).llmResult(llmResult).conceptTags(conceptTags).build();
     }
 }

--- a/src/main/java/com/ll/ilta/domain/image/dto/SupabaseResponseDto.java
+++ b/src/main/java/com/ll/ilta/domain/image/dto/SupabaseResponseDto.java
@@ -14,9 +14,4 @@ public class SupabaseResponseDto {
 
     @JsonProperty("Id")
     private String id;
-
-    private SupabaseResponseDto(String key, String id) {
-        this.key = key;
-        this.id = id;
-    }
 }

--- a/src/main/java/com/ll/ilta/domain/problem/dto/ProblemResponseDto.java
+++ b/src/main/java/com/ll/ilta/domain/problem/dto/ProblemResponseDto.java
@@ -1,9 +1,9 @@
 package com.ll.ilta.domain.problem.dto;
 
+import com.ll.ilta.domain.concept.dto.ConceptDto;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.Builder;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/ll/ilta/domain/problem/repository/ProblemRepositoryImpl.java
+++ b/src/main/java/com/ll/ilta/domain/problem/repository/ProblemRepositoryImpl.java
@@ -7,7 +7,7 @@ import static com.ll.ilta.domain.problem.entity.QProblemConcept.problemConcept;
 import static com.ll.ilta.domain.problem.entity.QProblemResult.problemResult;
 import static com.ll.ilta.domain.image.entity.QImage.image;
 
-import com.ll.ilta.domain.problem.dto.ConceptDto;
+import com.ll.ilta.domain.concept.dto.ConceptDto;
 import com.ll.ilta.domain.problem.dto.ProblemResponseDto;
 import com.ll.ilta.domain.problem.entity.ProblemResult;
 import com.ll.ilta.global.common.dto.Cursor;
@@ -108,12 +108,11 @@ public class ProblemRepositoryImpl implements ProblemRepositoryCustom {
     }
 
     private Map<Long, List<ConceptDto>> fetchConceptsMap(List<Long> problemIds) {
-        List<Tuple> tuples = queryFactory.select(problemConcept.problem.id, concept.id, concept.name, concept.description)
-            .from(problemConcept).join(problemConcept.concept, concept).where(problemConcept.problem.id.in(problemIds))
-            .fetch();
+        List<Tuple> tuples = queryFactory.select(problemConcept.problem.id, concept.id, concept.name,
+                concept.description).from(problemConcept).join(problemConcept.concept, concept)
+            .where(problemConcept.problem.id.in(problemIds)).fetch();
 
         return tuples.stream().collect(Collectors.groupingBy(t -> t.get(problemConcept.problem.id),
-            Collectors.mapping(t -> ConceptDto.of(t.get(concept.id), t.get(concept.name)),
-                Collectors.toList())));
+            Collectors.mapping(t -> ConceptDto.of(t.get(concept.id), t.get(concept.name)), Collectors.toList())));
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
- AiResponseDto 내 Concept id null 문제 수정  
- Concept description 저장 누락 문제 해결  
- Concept DTO와 Entity 필드 불일치 정리  

## ✅ 주요 변경 사항
### 저장 로직 순서 변경
기존에는 DTO 변환이 먼저였지만, **이제는 저장 후 변환**하는 구조로 변경되었습니다.
1. AI 서버에서 받은 `List<ConceptDto>`를 먼저 **DTO → Entity로 변환**
2. 변환된 Entity 리스트를 DB에 **저장** 
3. 저장된 Entity 리스트를 **DTO로 재변환**하여 응답

### 리팩토링  
- Entity: `@Builder` + private 생성자 적용해 생성 통제  
- DTO: `@Builder` 사용, `of()`는 빌더 호출 형태 유지  

## PR 유형

- [x] 버그 수정
- [x] 코드 리팩토링
- [x] 파일 혹은 폴더명 수정

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
