### PR TITLE
[AMT-124] 카카오 로그인 비밀번호 저장 로직 제거

### DIFF
--- a/src/main/java/com/ll/ilta/domain/member/v2/controller/AuthController.java
+++ b/src/main/java/com/ll/ilta/domain/member/v2/controller/AuthController.java
@@ -13,6 +13,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.Mapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -34,7 +36,7 @@ public class AuthController {
         description = "로그인 성공",
         content = @Content(schema = @Schema(implementation = MemberResponseDTO.JoinResultDTO.class))
     )
-    @GetMapping("/oauth") // Redirect URI
+    @PostMapping("/oauth") // Redirect URI
     public BaseResponse<MemberResponseDTO.JoinResultDTO> kakaoLogin(@RequestParam("code") String accessCode,
         HttpServletResponse httpServletResponse) {
         MemberResponseDTO.JoinResultDTO result = authService.oAuthLogin(accessCode, httpServletResponse);

--- a/src/main/java/com/ll/ilta/domain/member/v2/controller/AuthController.java
+++ b/src/main/java/com/ll/ilta/domain/member/v2/controller/AuthController.java
@@ -36,7 +36,7 @@ public class AuthController {
         description = "로그인 성공",
         content = @Content(schema = @Schema(implementation = MemberResponseDTO.JoinResultDTO.class))
     )
-    @PostMapping("/oauth") // Redirect URI
+    @GetMapping("/oauth") // Redirect URI
     public BaseResponse<MemberResponseDTO.JoinResultDTO> kakaoLogin(@RequestParam("code") String accessCode,
         HttpServletResponse httpServletResponse) {
         MemberResponseDTO.JoinResultDTO result = authService.oAuthLogin(accessCode, httpServletResponse);

--- a/src/main/java/com/ll/ilta/domain/member/v2/converter/AuthConverter.java
+++ b/src/main/java/com/ll/ilta/domain/member/v2/converter/AuthConverter.java
@@ -5,11 +5,10 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 public class AuthConverter {
 
-    public static Member toMember(String email, String nickname, String password, PasswordEncoder passwordEncoder) {
+    public static Member toMember(String email, String nickname) {
         return Member.builder()
             .email(email)
             .role("ROLE_USER")
-            .password(passwordEncoder.encode(password))
             .nickname(nickname)
             .build();
     }

--- a/src/main/java/com/ll/ilta/domain/member/v2/converter/MemberConverter.java
+++ b/src/main/java/com/ll/ilta/domain/member/v2/converter/MemberConverter.java
@@ -10,10 +10,9 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 @Slf4j
 public class MemberConverter {
 
-    public static Member toMember(MemberRequestDTO.JoinDTO joinDTO, PasswordEncoder passwordEncoder) {
+    public static Member toMember(MemberRequestDTO.JoinDTO joinDTO) {
         return Member.builder()
             .nickname(joinDTO.getNickname())
-            .password(passwordEncoder.encode(joinDTO.getPassword()))
             .email(joinDTO.getEmail())
             .role(joinDTO.getRole())
             .build();

--- a/src/main/java/com/ll/ilta/domain/member/v2/entity/Member.java
+++ b/src/main/java/com/ll/ilta/domain/member/v2/entity/Member.java
@@ -25,14 +25,12 @@ public class Member extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "member_id")
+    @Column(name = "id")
     private Long id;
 
     private String nickname;
 
     private String email;
-
-    private String password;
 
     private String role;
 

--- a/src/main/java/com/ll/ilta/domain/member/v2/service/AuthServiceImpl.java
+++ b/src/main/java/com/ll/ilta/domain/member/v2/service/AuthServiceImpl.java
@@ -41,9 +41,7 @@ public class AuthServiceImpl implements AuthService {
             return MemberConverter.toJoinResultDTO(member, token);
         } else {
             Member member = AuthConverter.toMember(kakaoProfile.getKakao_account().getEmail(),
-                kakaoProfile.getKakao_account().getProfile().getNickname(),
-                "1234",
-                passwordEncoder);
+                kakaoProfile.getKakao_account().getProfile().getNickname());
             memberRepository.save(member);
 
             String token = jwtUtil.createAccessToken(member.getEmail(), member.getRole());

--- a/src/main/java/com/ll/ilta/global/security/v2/member/PrincipalDetails.java
+++ b/src/main/java/com/ll/ilta/global/security/v2/member/PrincipalDetails.java
@@ -34,9 +34,8 @@ public class PrincipalDetails implements UserDetails {
 
     @Override
     public String getPassword() {
-        return member.getPassword();
+        return null;
     }
-
     @Override
     public String getUsername() {
         return member.getEmail();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,7 +13,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: update
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,7 +13,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect

--- a/src/test/java/com/ll/ilta/setup/DatabaseConnectionTest.java
+++ b/src/test/java/com/ll/ilta/setup/DatabaseConnectionTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Disabled("전체 테스트 제외")
 @SpringBootTest
@@ -18,10 +17,8 @@ class DatabaseConnectionTest {
 
     @Autowired
     private DataSource dataSource;
-    @Autowired
-    private PasswordEncoder passwordEncoder;
 
-    @DisplayName("DB 연결 테스트 & PasswordEncoder 테스트")
+    @DisplayName("DB 연결 테스트")
     @Test
     void testDatabaseConnection() throws SQLException {
         try (Connection connection = dataSource.getConnection()) {
@@ -30,13 +27,6 @@ class DatabaseConnectionTest {
             String dbName = connection.getMetaData().getDatabaseProductName();
             String dbVersion = connection.getMetaData().getDatabaseProductVersion();
             System.out.println("DB 연결 성공: " + dbName + " " + dbVersion);
-
-            String rawPassword = "de1234";
-            String encoded = passwordEncoder.encode(rawPassword);
-            System.out.println("비밀번호 인코딩 결과 = " + encoded);
-
-            boolean matches = passwordEncoder.matches(rawPassword, encoded);
-            System.out.println("비밀번호 일치 여부 = " + matches);
         }
     }
 }

--- a/src/test/java/com/ll/ilta/setup/DatabaseConnectionTest.java
+++ b/src/test/java/com/ll/ilta/setup/DatabaseConnectionTest.java
@@ -2,15 +2,15 @@ package com.ll.ilta.setup;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.sql.Connection;
+import java.sql.SQLException;
+import javax.sql.DataSource;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-
-import javax.sql.DataSource;
-import java.sql.Connection;
-import java.sql.SQLException;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Disabled("전체 테스트 제외")
 @SpringBootTest
@@ -18,8 +18,10 @@ class DatabaseConnectionTest {
 
     @Autowired
     private DataSource dataSource;
+    @Autowired
+    private PasswordEncoder passwordEncoder;
 
-    @DisplayName("DB 연결 테스트")
+    @DisplayName("DB 연결 테스트 & PasswordEncoder 테스트")
     @Test
     void testDatabaseConnection() throws SQLException {
         try (Connection connection = dataSource.getConnection()) {
@@ -28,6 +30,13 @@ class DatabaseConnectionTest {
             String dbName = connection.getMetaData().getDatabaseProductName();
             String dbVersion = connection.getMetaData().getDatabaseProductVersion();
             System.out.println("DB 연결 성공: " + dbName + " " + dbVersion);
+
+            String rawPassword = "de1234";
+            String encoded = passwordEncoder.encode(rawPassword);
+            System.out.println("비밀번호 인코딩 결과 = " + encoded);
+
+            boolean matches = passwordEncoder.matches(rawPassword, encoded);
+            System.out.println("비밀번호 일치 여부 = " + matches);
         }
     }
 }


### PR DESCRIPTION
## 📝작업 내용
- 카카오 OAuth 로그인 구현 중 비밀번호를 저장할 필요가 없어 관련 로직과 필드 제거
## ✅ 주요 변경 사항
- Member 엔티티에서 `password` 필드 제거
- OAuth 로그인 서비스(AuthService)에서 비밀번호 관련 처리 코드 삭제

- 테스트 코드 및 DTO에서 비밀번호 필드 제거
## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [x] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
