### PR TITLE
[AMT-126] 자녀 정보 조회/수정 기능 개발

### DIFF
--- a/src/main/java/com/ll/ilta/domain/concept/repository/ConceptRepository.java
+++ b/src/main/java/com/ll/ilta/domain/concept/repository/ConceptRepository.java
@@ -1,9 +1,8 @@
 package com.ll.ilta.domain.concept.repository;
 
 import com.ll.ilta.domain.concept.entity.Concept;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ConceptRepository extends JpaRepository<Concept, Long> {
 

--- a/src/main/java/com/ll/ilta/domain/favorite/repository/FavoriteRepositoryCustom.java
+++ b/src/main/java/com/ll/ilta/domain/favorite/repository/FavoriteRepositoryCustom.java
@@ -4,5 +4,6 @@ import com.ll.ilta.domain.favorite.dto.FavoriteResponseDto;
 import java.util.List;
 
 public interface FavoriteRepositoryCustom {
+
     List<FavoriteResponseDto> findFavoriteWithCursor(Long memberId, String afterCursor, int limit);
 }

--- a/src/main/java/com/ll/ilta/domain/favorite/repository/FavoriteRepositoryImpl.java
+++ b/src/main/java/com/ll/ilta/domain/favorite/repository/FavoriteRepositoryImpl.java
@@ -1,14 +1,14 @@
 package com.ll.ilta.domain.favorite.repository;
 
+import static com.ll.ilta.domain.concept.entity.QConcept.concept;
 import static com.ll.ilta.domain.favorite.entity.QFavorite.favorite;
 import static com.ll.ilta.domain.image.entity.QImage.image;
-import static com.ll.ilta.domain.concept.entity.QConcept.concept;
 import static com.ll.ilta.domain.problem.entity.QProblem.problem;
 import static com.ll.ilta.domain.problem.entity.QProblemConcept.problemConcept;
 import static com.ll.ilta.domain.problem.entity.QProblemResult.problemResult;
 
-import com.ll.ilta.domain.favorite.dto.FavoriteResponseDto;
 import com.ll.ilta.domain.concept.dto.ConceptDto;
+import com.ll.ilta.domain.favorite.dto.FavoriteResponseDto;
 import com.ll.ilta.domain.problem.entity.ProblemResult;
 import com.ll.ilta.global.cursor.dto.Cursor;
 import com.ll.ilta.global.cursor.service.CursorUtil;

--- a/src/main/java/com/ll/ilta/domain/image/client/AiFeignClient.java
+++ b/src/main/java/com/ll/ilta/domain/image/client/AiFeignClient.java
@@ -3,10 +3,10 @@ package com.ll.ilta.domain.image.client;
 import com.ll.ilta.domain.image.dto.AiResponseDto;
 import com.ll.ilta.global.config.FeignConfig;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
-import org.springframework.http.MediaType;
 
 @FeignClient(name = "aiFeignClient", url = "${ai.service.url}", configuration = FeignConfig.class)
 public interface AiFeignClient {

--- a/src/main/java/com/ll/ilta/domain/member/controller/AuthController.java
+++ b/src/main/java/com/ll/ilta/domain/member/controller/AuthController.java
@@ -1,6 +1,6 @@
 package com.ll.ilta.domain.member.controller;
 
-import com.ll.ilta.domain.member.dto.MemberResponseDTO;
+import com.ll.ilta.domain.member.dto.MemberResponseDTO.JoinResultDTO;
 import com.ll.ilta.domain.member.service.AuthService;
 import com.ll.ilta.global.payload.response.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -23,19 +23,12 @@ public class AuthController {
 
     private final AuthService authService;
 
-    @Operation(
-        summary = "카카오 로그인",
-        description = "카카오 인가코드를 이용해 로그인 및 자동 회원가입 처리"
-    )
-    @ApiResponse(
-        responseCode = "200",
-        description = "로그인 성공",
-        content = @Content(schema = @Schema(implementation = MemberResponseDTO.JoinResultDTO.class))
-    )
+    @Operation(summary = "카카오 로그인", description = "카카오 인가코드를 이용해 로그인 및 자동 회원가입 처리")
+    @ApiResponse(responseCode = "200", description = "로그인 성공", content = @Content(schema = @Schema(implementation = JoinResultDTO.class)))
     @GetMapping("/oauth") // Redirect URI
-    public BaseResponse<MemberResponseDTO.JoinResultDTO> kakaoLogin(@RequestParam("code") String accessCode,
+    public BaseResponse<JoinResultDTO> kakaoLogin(@RequestParam("code") String accessCode,
         HttpServletResponse httpServletResponse) {
-        MemberResponseDTO.JoinResultDTO result = authService.oAuthLogin(accessCode, httpServletResponse);
+        JoinResultDTO result = authService.oAuthLogin(accessCode, httpServletResponse);
         return BaseResponse.onSuccess(result);
     }
 

--- a/src/main/java/com/ll/ilta/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ll/ilta/domain/member/controller/MemberController.java
@@ -5,8 +5,6 @@ import static com.ll.ilta.domain.member.converter.MemberConverter.toMemberPrevie
 import static com.ll.ilta.domain.member.converter.MemberConverter.toMemberPreviewListDTO;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ll.ilta.domain.member.dto.MemberRequestDTO.ChildRequestDTO;
 import com.ll.ilta.domain.member.dto.MemberRequestDTO.UpdateMemberDTO;
 import com.ll.ilta.domain.member.dto.MemberResponseDTO.ChildResponseDTO;
@@ -40,21 +38,11 @@ public class MemberController {
 
     @Operation(summary = "내 정보 조회", description = "JWT로 인증된 사용자 정보 조회")
     @GetMapping("/me/profile")
-    public BaseResponse<MemberPreviewDTO> readMember(
-        @AuthenticationPrincipal PrincipalDetails principalDetails) {
+    public BaseResponse<MemberPreviewDTO> readMember(@AuthenticationPrincipal PrincipalDetails principalDetails) {
 
         Long memberId = principalDetails.getMemberId();
-
         Member member = memberService.readMember(memberId);
-
         MemberPreviewDTO dto = toMemberPreviewDTO(member);
-
-        try {
-            String json = new ObjectMapper().writeValueAsString(dto);
-            System.out.println(">>>> 직렬화된 JSON: " + json);
-        } catch (JsonProcessingException e) {
-            System.out.println(">>>> JSON 직렬화 실패: " + e.getMessage());
-        }
 
         return BaseResponse.onSuccess(dto);
     }
@@ -68,8 +56,7 @@ public class MemberController {
 
     @Operation(summary = "회원 정보 수정", description = "이름, 프로필 사진 수정")
     @PatchMapping("/me/profile")
-    public BaseResponse<MemberPreviewDTO> updateMyInfo(
-        @AuthenticationPrincipal PrincipalDetails principalDetails,
+    public BaseResponse<MemberPreviewDTO> updateMyInfo(@AuthenticationPrincipal PrincipalDetails principalDetails,
         @RequestBody UpdateMemberDTO updateMemberDTO) {
         Long memberId = principalDetails.getMemberId();
         Member member = memberService.updateMyInfo(updateMemberDTO, memberId);

--- a/src/main/java/com/ll/ilta/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ll/ilta/domain/member/controller/MemberController.java
@@ -1,13 +1,17 @@
 package com.ll.ilta.domain.member.controller;
 
+import static com.ll.ilta.domain.member.converter.MemberConverter.toChildDto;
+import static com.ll.ilta.domain.member.converter.MemberConverter.toMemberPreviewDTO;
+import static com.ll.ilta.domain.member.converter.MemberConverter.toMemberPreviewListDTO;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.ll.ilta.domain.member.converter.MemberConverter;
-import com.ll.ilta.domain.member.dto.MemberRequestDTO;
-import com.ll.ilta.domain.member.dto.MemberResponseDTO;
-import com.ll.ilta.domain.member.dto.MemberResponseDTO.ChildDTO;
+import com.ll.ilta.domain.member.dto.MemberRequestDTO.ChildRequestDTO;
+import com.ll.ilta.domain.member.dto.MemberRequestDTO.UpdateMemberDTO;
+import com.ll.ilta.domain.member.dto.MemberResponseDTO.ChildResponseDTO;
+import com.ll.ilta.domain.member.dto.MemberResponseDTO.MemberPreviewDTO;
+import com.ll.ilta.domain.member.dto.MemberResponseDTO.MemberPreviewListDTO;
 import com.ll.ilta.domain.member.entity.Member;
 import com.ll.ilta.domain.member.service.MemberService;
 import com.ll.ilta.global.payload.response.BaseResponse;
@@ -36,14 +40,14 @@ public class MemberController {
 
     @Operation(summary = "내 정보 조회", description = "JWT로 인증된 사용자 정보 조회")
     @GetMapping("/me/profile")
-    public BaseResponse<MemberResponseDTO.MemberPreviewDTO> readMember(
+    public BaseResponse<MemberPreviewDTO> readMember(
         @AuthenticationPrincipal PrincipalDetails principalDetails) {
 
         Long memberId = principalDetails.getMemberId();
 
         Member member = memberService.readMember(memberId);
 
-        MemberResponseDTO.MemberPreviewDTO dto = MemberConverter.toMemberPreviewDTO(member);
+        MemberPreviewDTO dto = toMemberPreviewDTO(member);
 
         try {
             String json = new ObjectMapper().writeValueAsString(dto);
@@ -57,40 +61,40 @@ public class MemberController {
 
     @Operation(summary = "[관리자 전용] 전체 회원 조회", description = "관리자 기능이라 추후 구현 예정")
     @GetMapping("/admin/all")
-    public BaseResponse<MemberResponseDTO.MemberPreviewListDTO> readAllMember() {
+    public BaseResponse<MemberPreviewListDTO> readAllMember() {
         List<Member> memberList = memberService.readAllMembers();
-        return BaseResponse.onSuccess(MemberConverter.toMemberPreviewListDTO(memberList));
+        return BaseResponse.onSuccess(toMemberPreviewListDTO(memberList));
     }
 
     @Operation(summary = "회원 정보 수정", description = "이름, 프로필 사진 수정")
     @PatchMapping("/me/profile")
-    public BaseResponse<MemberResponseDTO.MemberPreviewDTO> updateMyInfo(
+    public BaseResponse<MemberPreviewDTO> updateMyInfo(
         @AuthenticationPrincipal PrincipalDetails principalDetails,
-        @RequestBody MemberRequestDTO.UpdateMemberDTO updateMemberDTO) {
+        @RequestBody UpdateMemberDTO updateMemberDTO) {
         Long memberId = principalDetails.getMemberId();
         Member member = memberService.updateMyInfo(updateMemberDTO, memberId);
-        return BaseResponse.onSuccess(MemberConverter.toMemberPreviewDTO(member));
+        return BaseResponse.onSuccess(toMemberPreviewDTO(member));
     }
 
     @Operation(summary = "자녀 정보 조회", description = "자녀 이름 학년 조회")
     @GetMapping("/child/profile")
-    public BaseResponse<ChildDTO> readChild(@AuthenticationPrincipal PrincipalDetails principalDetails) {
+    public BaseResponse<ChildResponseDTO> readChild(@AuthenticationPrincipal PrincipalDetails principalDetails) {
 
         Long memberId = principalDetails.getMemberId();
         Member member = memberService.readMember(memberId);
 
-        ChildDTO childDTO = MemberConverter.toChildDto(member);
+        ChildResponseDTO childResponseDTO = toChildDto(member);
 
-        return BaseResponse.onSuccess(childDTO);
+        return BaseResponse.onSuccess(childResponseDTO);
     }
 
     @Operation(summary = "자녀 정보 수정", description = "자녀 이름, 학년 수정")
     @PatchMapping("/child/profile")
-    public BaseResponse<ChildDTO> updateChild(@AuthenticationPrincipal PrincipalDetails principalDetails,
-        @RequestBody MemberRequestDTO.ChildDTO childDTO) {
+    public BaseResponse<ChildResponseDTO> updateChild(@AuthenticationPrincipal PrincipalDetails principalDetails,
+        @RequestBody ChildRequestDTO childRequestDTO) {
         Long memberId = principalDetails.getMemberId();
-        Member member = memberService.updateChild(childDTO, memberId);
-        return BaseResponse.onSuccess(MemberConverter.toChildDto(member));
+        Member member = memberService.updateChild(childRequestDTO, memberId);
+        return BaseResponse.onSuccess(toChildDto(member));
     }
 
 //    @Operation(summary = "카카오 로그아웃", description = "카카오 토큰 연동 해제")

--- a/src/main/java/com/ll/ilta/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ll/ilta/domain/member/controller/MemberController.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ll.ilta.domain.member.converter.MemberConverter;
 import com.ll.ilta.domain.member.dto.MemberRequestDTO;
 import com.ll.ilta.domain.member.dto.MemberResponseDTO;
+import com.ll.ilta.domain.member.dto.MemberResponseDTO.ChildDTO;
 import com.ll.ilta.domain.member.entity.Member;
 import com.ll.ilta.domain.member.service.MemberService;
 import com.ll.ilta.global.payload.response.BaseResponse;
@@ -39,13 +40,10 @@ public class MemberController {
         @AuthenticationPrincipal PrincipalDetails principalDetails) {
 
         Long memberId = principalDetails.getMemberId();
-        System.out.println(">>>> memberId: " + memberId);
 
         Member member = memberService.readMember(memberId);
-        System.out.println(">>>> memberService result: " + member);
 
         MemberResponseDTO.MemberPreviewDTO dto = MemberConverter.toMemberPreviewDTO(member);
-        System.out.println(">>>> 컨트롤러 result 객체 확인: " + dto);
 
         try {
             String json = new ObjectMapper().writeValueAsString(dto);
@@ -74,6 +72,27 @@ public class MemberController {
         return BaseResponse.onSuccess(MemberConverter.toMemberPreviewDTO(member));
     }
 
+    @Operation(summary = "자녀 정보 조회", description = "자녀 이름 학년 조회")
+    @GetMapping("/child/profile")
+    public BaseResponse<ChildDTO> readChild(@AuthenticationPrincipal PrincipalDetails principalDetails) {
+
+        Long memberId = principalDetails.getMemberId();
+        Member member = memberService.readMember(memberId);
+
+        ChildDTO childDTO = MemberConverter.toChildDto(member);
+
+        return BaseResponse.onSuccess(childDTO);
+    }
+
+    @Operation(summary = "자녀 정보 수정", description = "자녀 이름, 학년 수정")
+    @PatchMapping("/child/profile")
+    public BaseResponse<ChildDTO> updateChild(@AuthenticationPrincipal PrincipalDetails principalDetails,
+        @RequestBody MemberRequestDTO.ChildDTO childDTO) {
+        Long memberId = principalDetails.getMemberId();
+        Member member = memberService.updateChild(childDTO, memberId);
+        return BaseResponse.onSuccess(MemberConverter.toChildDto(member));
+    }
+
 //    @Operation(summary = "카카오 로그아웃", description = "카카오 토큰 연동 해제")
 //    @PostMapping("/logout")
 //    public BaseResponse<String> kakaoLogout(@AuthenticationPrincipal PrincipalDetails principalDetails) {
@@ -90,18 +109,13 @@ public class MemberController {
     }
 
 
-    @Operation(
-        summary = "자녀 정보 유무 확인",
-        description = "카카오 로그인 후 자녀 이름과 학년 유무를 체크하여 홈 화면 이동 판단"
-    )
-    @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "자녀 정보 존재 여부 반환"),
-        @ApiResponse(responseCode = "401", description = "인증 실패")
-    })
+    @Operation(summary = "자녀 정보 유무 확인", description = "카카오 로그인 후 자녀 이름과 학년 유무를 체크하여 홈 화면 이동 판단")
+    @ApiResponses({@ApiResponse(responseCode = "200", description = "자녀 정보 존재 여부 반환"),
+        @ApiResponse(responseCode = "401", description = "인증 실패")})
     @GetMapping("/me/child-info/exist")
     public BaseResponse<Boolean> existsChildInfo(@AuthenticationPrincipal PrincipalDetails principalDetails) {
         Long memberId = principalDetails.getMemberId();
-        boolean hasChild = memberService.existsChildInfo(memberId);
+        boolean hasChild = memberService.existsChild(memberId);
         return BaseResponse.onSuccess(hasChild);
     }
 }

--- a/src/main/java/com/ll/ilta/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/ll/ilta/domain/member/converter/MemberConverter.java
@@ -23,13 +23,12 @@ public class MemberConverter {
     }
 
     public static MemberPreviewDTO toMemberPreviewDTO(Member member) {
-        return MemberPreviewDTO.builder().memberId(member.getId()).nickname(member.getNickname())
-            .email(member.getEmail()).build();
+        return MemberPreviewDTO.builder().nickname(member.getNickname()).email(member.getEmail()).build();
     }
 
     public static ChildResponseDTO toChildDto(Member member) {
-        ChildResponseDTO childResponseDTO = ChildResponseDTO.builder().memberId(member.getId())
-            .childName(member.getChildName()).childGrade(member.getChildGrade()).build();
+        ChildResponseDTO childResponseDTO = ChildResponseDTO.builder().childName(member.getChildName())
+            .childGrade(member.getChildGrade()).build();
         return childResponseDTO;
     }
 

--- a/src/main/java/com/ll/ilta/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/ll/ilta/domain/member/converter/MemberConverter.java
@@ -2,6 +2,7 @@ package com.ll.ilta.domain.member.converter;
 
 import com.ll.ilta.domain.member.dto.MemberRequestDTO;
 import com.ll.ilta.domain.member.dto.MemberResponseDTO;
+import com.ll.ilta.domain.member.dto.MemberResponseDTO.ChildDTO;
 import com.ll.ilta.domain.member.entity.Member;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
@@ -29,15 +30,21 @@ public class MemberConverter {
 
     public static MemberResponseDTO.MemberPreviewDTO toMemberPreviewDTO(Member member) {
         MemberResponseDTO.MemberPreviewDTO dto = MemberResponseDTO.MemberPreviewDTO.builder()
-            // return MemberResponseDTO.MemberPreviewDTO.builder()
             .memberId(member.getId())
             .nickname(member.getNickname())
             .updateAt(member.getUpdatedAt())
             .createAt(member.getCreatedAt())
             .build();
-        log.info("DTO 변환 결과 => memberId: {}, nickname: {}, createdAt: {}, updatedAt: {}",
-            dto.getMemberId(), dto.getNickname(), dto.getCreateAt(), dto.getUpdateAt());
         return dto;
+    }
+
+    public static ChildDTO toChildDto(Member member) {
+        ChildDTO childDTO = ChildDTO.builder()
+            .memberId(member.getId())
+            .childName(member.getChildName())
+            .childGrade(member.getChildGrade())
+            .build();
+        return childDTO;
     }
 
     public static MemberResponseDTO.MemberPreviewListDTO toMemberPreviewListDTO(List<Member> memberList) {
@@ -49,14 +56,4 @@ public class MemberConverter {
             .memberPreviewDTOList(memberPreviewDTOList)
             .build();
     }
-
-//    public static MemberResponseDTO.ChildInfoDTO toChildInfoDTO(Member member) {
-//        return MemberResponseDTO.ChildInfoDTO.builder()
-//            .childId(member.getId())
-//            .childName(member.getName())
-//            .childGrade(member.getGrade())
-//            .createdAt(member.getCreatedAt())
-//            .updatedAt(member.getUpdatedAt())
-//            .build();
-//    }
 }

--- a/src/main/java/com/ll/ilta/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/ll/ilta/domain/member/converter/MemberConverter.java
@@ -1,8 +1,10 @@
 package com.ll.ilta.domain.member.converter;
 
-import com.ll.ilta.domain.member.dto.MemberRequestDTO;
-import com.ll.ilta.domain.member.dto.MemberResponseDTO;
-import com.ll.ilta.domain.member.dto.MemberResponseDTO.ChildDTO;
+import com.ll.ilta.domain.member.dto.MemberRequestDTO.JoinDTO;
+import com.ll.ilta.domain.member.dto.MemberResponseDTO.ChildResponseDTO;
+import com.ll.ilta.domain.member.dto.MemberResponseDTO.JoinResultDTO;
+import com.ll.ilta.domain.member.dto.MemberResponseDTO.MemberPreviewDTO;
+import com.ll.ilta.domain.member.dto.MemberResponseDTO.MemberPreviewListDTO;
 import com.ll.ilta.domain.member.entity.Member;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
@@ -10,50 +12,32 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class MemberConverter {
 
-    public static Member toMember(MemberRequestDTO.JoinDTO joinDTO) {
-        return Member.builder()
-            .nickname(joinDTO.getNickname())
-            .email(joinDTO.getEmail())
-            .role(joinDTO.getRole())
+    public static Member toMember(JoinDTO joinDTO) {
+        return Member.builder().nickname(joinDTO.getNickname()).email(joinDTO.getEmail()).role(joinDTO.getRole())
             .build();
     }
 
-    public static MemberResponseDTO.JoinResultDTO toJoinResultDTO(Member member, String accessToken) {
-        return MemberResponseDTO.JoinResultDTO.builder()
-            .memberId(member.getId())
-            .createAt(member.getCreatedAt())
-            .nickname(member.getNickname())
-            .email(member.getEmail())
-            .accessToken(accessToken)
-            .build();
+    public static JoinResultDTO toJoinResultDTO(Member member, String accessToken) {
+        return JoinResultDTO.builder().memberId(member.getId()).createAt(member.getCreatedAt())
+            .nickname(member.getNickname()).email(member.getEmail()).accessToken(accessToken).build();
     }
 
-    public static MemberResponseDTO.MemberPreviewDTO toMemberPreviewDTO(Member member) {
-        MemberResponseDTO.MemberPreviewDTO dto = MemberResponseDTO.MemberPreviewDTO.builder()
-            .memberId(member.getId())
-            .nickname(member.getNickname())
-            .updateAt(member.getUpdatedAt())
-            .createAt(member.getCreatedAt())
-            .build();
+    public static MemberPreviewDTO toMemberPreviewDTO(Member member) {
+        MemberPreviewDTO dto = MemberPreviewDTO.builder().memberId(member.getId()).nickname(member.getNickname())
+            .updateAt(member.getUpdatedAt()).createAt(member.getCreatedAt()).build();
         return dto;
     }
 
-    public static ChildDTO toChildDto(Member member) {
-        ChildDTO childDTO = ChildDTO.builder()
-            .memberId(member.getId())
-            .childName(member.getChildName())
-            .childGrade(member.getChildGrade())
-            .build();
-        return childDTO;
+    public static ChildResponseDTO toChildDto(Member member) {
+        ChildResponseDTO childResponseDTO = ChildResponseDTO.builder().memberId(member.getId())
+            .childName(member.getChildName()).childGrade(member.getChildGrade()).build();
+        return childResponseDTO;
     }
 
-    public static MemberResponseDTO.MemberPreviewListDTO toMemberPreviewListDTO(List<Member> memberList) {
-        List<MemberResponseDTO.MemberPreviewDTO> memberPreviewDTOList = memberList.stream()
-            .map(MemberConverter::toMemberPreviewDTO)
+    public static MemberPreviewListDTO toMemberPreviewListDTO(List<Member> memberList) {
+        List<MemberPreviewDTO> memberPreviewDTOList = memberList.stream().map(MemberConverter::toMemberPreviewDTO)
             .toList();
 
-        return MemberResponseDTO.MemberPreviewListDTO.builder()
-            .memberPreviewDTOList(memberPreviewDTOList)
-            .build();
+        return MemberPreviewListDTO.builder().memberPreviewDTOList(memberPreviewDTOList).build();
     }
 }

--- a/src/main/java/com/ll/ilta/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/ll/ilta/domain/member/converter/MemberConverter.java
@@ -23,9 +23,8 @@ public class MemberConverter {
     }
 
     public static MemberPreviewDTO toMemberPreviewDTO(Member member) {
-        MemberPreviewDTO dto = MemberPreviewDTO.builder().memberId(member.getId()).nickname(member.getNickname())
-            .updateAt(member.getUpdatedAt()).createAt(member.getCreatedAt()).build();
-        return dto;
+        return MemberPreviewDTO.builder().memberId(member.getId()).nickname(member.getNickname())
+            .email(member.getEmail()).build();
     }
 
     public static ChildResponseDTO toChildDto(Member member) {

--- a/src/main/java/com/ll/ilta/domain/member/dto/MemberRequestDTO.java
+++ b/src/main/java/com/ll/ilta/domain/member/dto/MemberRequestDTO.java
@@ -39,7 +39,7 @@ public class MemberRequestDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
-    public static class ChildDTO {
+    public static class ChildRequestDTO {
 
         @Schema(description = "자녀 이름", example = "홍길동")
         private String childName;

--- a/src/main/java/com/ll/ilta/domain/member/dto/MemberRequestDTO.java
+++ b/src/main/java/com/ll/ilta/domain/member/dto/MemberRequestDTO.java
@@ -39,26 +39,12 @@ public class MemberRequestDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
-    public static class ChildInfoDTO {
+    public static class ChildDTO {
 
         @Schema(description = "자녀 이름", example = "홍길동")
         private String childName;
 
         @Schema(description = "자녀 학년", example = "3")
-        private Integer childGrade;
-    }
-
-    @Getter
-    @Setter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    @Builder
-    public static class UpdateChildInfoDTO {
-
-        @Schema(description = "자녀 이름", example = "홍길순")
-        private String childName;
-
-        @Schema(description = "자녀 학년", example = "4")
         private Integer childGrade;
     }
 }

--- a/src/main/java/com/ll/ilta/domain/member/dto/MemberResponseDTO.java
+++ b/src/main/java/com/ll/ilta/domain/member/dto/MemberResponseDTO.java
@@ -48,21 +48,15 @@ public class MemberResponseDTO {
     @AllArgsConstructor
     @NoArgsConstructor
     @Builder
-    public static class ChildInfoDTO {
+    public static class ChildDTO {
 
-        @Schema(description = "자녀 ID", example = "2")
-        private Long childId;
+        @Schema(description = "회원 ID(회원-자녀 일대일)", example = "2")
+        private Long memberId;
 
         @Schema(description = "자녀 이름", example = "홍길동")
         private String childName;
 
         @Schema(description = "자녀 학년", example = "3")
         private Integer childGrade;
-
-        @Schema(description = "수정일", example = "2025-07-26T12:10:00")
-        private LocalDateTime updatedAt;
-
-        @Schema(description = "등록일", example = "2025-07-26T12:00:00")
-        private LocalDateTime createdAt;
     }
 }

--- a/src/main/java/com/ll/ilta/domain/member/dto/MemberResponseDTO.java
+++ b/src/main/java/com/ll/ilta/domain/member/dto/MemberResponseDTO.java
@@ -31,8 +31,7 @@ public class MemberResponseDTO {
 
         private Long memberId;
         private String nickname;
-        private LocalDateTime updateAt;
-        private LocalDateTime createAt;
+        private String email;
     }
 
     @Getter

--- a/src/main/java/com/ll/ilta/domain/member/dto/MemberResponseDTO.java
+++ b/src/main/java/com/ll/ilta/domain/member/dto/MemberResponseDTO.java
@@ -1,6 +1,5 @@
 package com.ll.ilta.domain.member.dto;
 
-import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -29,7 +28,6 @@ public class MemberResponseDTO {
     @Builder
     public static class MemberPreviewDTO {
 
-        private Long memberId;
         private String nickname;
         private String email;
     }
@@ -48,9 +46,6 @@ public class MemberResponseDTO {
     @NoArgsConstructor
     @Builder
     public static class ChildResponseDTO {
-
-        @Schema(description = "회원 ID(회원-자녀 일대일)", example = "2")
-        private Long memberId;
 
         private String childName;
         private Integer childGrade;

--- a/src/main/java/com/ll/ilta/domain/member/dto/MemberResponseDTO.java
+++ b/src/main/java/com/ll/ilta/domain/member/dto/MemberResponseDTO.java
@@ -48,15 +48,12 @@ public class MemberResponseDTO {
     @AllArgsConstructor
     @NoArgsConstructor
     @Builder
-    public static class ChildDTO {
+    public static class ChildResponseDTO {
 
         @Schema(description = "회원 ID(회원-자녀 일대일)", example = "2")
         private Long memberId;
 
-        @Schema(description = "자녀 이름", example = "홍길동")
         private String childName;
-
-        @Schema(description = "자녀 학년", example = "3")
         private Integer childGrade;
     }
 }

--- a/src/main/java/com/ll/ilta/domain/member/entity/Member.java
+++ b/src/main/java/com/ll/ilta/domain/member/entity/Member.java
@@ -1,5 +1,6 @@
 package com.ll.ilta.domain.member.entity;
 
+import com.ll.ilta.domain.member.dto.MemberRequestDTO.ChildDTO;
 import com.ll.ilta.global.jpa.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -41,8 +42,12 @@ public class Member extends BaseEntity {
 
     private Integer childGrade;
 
-    public void updateMemberInfo(String nickname) {
+    public void updateMember(String nickname) {
         this.nickname = nickname;
-        log.info("Updated member info => id: {}, nickname: {}", this.id, this.nickname);
+    }
+
+    public void updateChild(ChildDTO childDTO) {
+        this.childName = childDTO.getChildName();
+        this.childGrade = childDTO.getChildGrade();
     }
 }

--- a/src/main/java/com/ll/ilta/domain/member/entity/Member.java
+++ b/src/main/java/com/ll/ilta/domain/member/entity/Member.java
@@ -1,6 +1,5 @@
 package com.ll.ilta.domain.member.entity;
 
-import com.ll.ilta.domain.member.dto.MemberRequestDTO.ChildDTO;
 import com.ll.ilta.global.jpa.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -46,8 +45,8 @@ public class Member extends BaseEntity {
         this.nickname = nickname;
     }
 
-    public void updateChild(ChildDTO childDTO) {
-        this.childName = childDTO.getChildName();
-        this.childGrade = childDTO.getChildGrade();
+    public void updateChild(String childName, Integer childGrade) {
+        this.childName = childName;
+        this.childGrade = childGrade;
     }
 }

--- a/src/main/java/com/ll/ilta/domain/member/service/AuthService.java
+++ b/src/main/java/com/ll/ilta/domain/member/service/AuthService.java
@@ -5,5 +5,5 @@ import jakarta.servlet.http.HttpServletResponse;
 
 public interface AuthService {
 
-    MemberResponseDTO.JoinResultDTO  oAuthLogin(String accessCode, HttpServletResponse httpServletResponse);
+    MemberResponseDTO.JoinResultDTO oAuthLogin(String accessCode, HttpServletResponse httpServletResponse);
 }

--- a/src/main/java/com/ll/ilta/domain/member/service/MemberService.java
+++ b/src/main/java/com/ll/ilta/domain/member/service/MemberService.java
@@ -1,6 +1,6 @@
 package com.ll.ilta.domain.member.service;
 
-import com.ll.ilta.domain.member.dto.MemberRequestDTO.ChildDTO;
+import com.ll.ilta.domain.member.dto.MemberRequestDTO.ChildRequestDTO;
 import com.ll.ilta.domain.member.dto.MemberRequestDTO.UpdateMemberDTO;
 import com.ll.ilta.domain.member.entity.Member;
 import java.util.List;
@@ -17,5 +17,5 @@ public interface MemberService {
 
     Member updateMyInfo(UpdateMemberDTO updateMemberDTO, Long memberId); // 로그인 사용자 기준
 
-    Member updateChild(ChildDTO childDTO, Long memberId); // 로그인 사용자 기준
+    Member updateChild(ChildRequestDTO childRequestDTO, Long memberId); // 로그인 사용자 기준
 }

--- a/src/main/java/com/ll/ilta/domain/member/service/MemberService.java
+++ b/src/main/java/com/ll/ilta/domain/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.ll.ilta.domain.member.service;
 
-import com.ll.ilta.domain.member.dto.MemberRequestDTO;
+import com.ll.ilta.domain.member.dto.MemberRequestDTO.ChildDTO;
+import com.ll.ilta.domain.member.dto.MemberRequestDTO.UpdateMemberDTO;
 import com.ll.ilta.domain.member.entity.Member;
 import java.util.List;
 
@@ -10,9 +11,11 @@ public interface MemberService {
 
     List<Member> readAllMembers();
 
-    boolean existsChildInfo(Long memberId); // 로그인 사용자 기준
+    boolean existsChild(Long memberId); // 로그인 사용자 기준
 
     void deleteMyInfo(Long memberId); // 로그인 사용자 기준
 
-    Member updateMyInfo(MemberRequestDTO.UpdateMemberDTO updateMemberDTO, Long memberId); // 로그인 사용자 기준
+    Member updateMyInfo(UpdateMemberDTO updateMemberDTO, Long memberId); // 로그인 사용자 기준
+
+    Member updateChild(ChildDTO childDTO, Long memberId); // 로그인 사용자 기준
 }

--- a/src/main/java/com/ll/ilta/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/ll/ilta/domain/member/service/MemberServiceImpl.java
@@ -2,6 +2,7 @@ package com.ll.ilta.domain.member.service;
 
 
 import com.ll.ilta.domain.member.dto.MemberRequestDTO;
+import com.ll.ilta.domain.member.dto.MemberRequestDTO.ChildDTO;
 import com.ll.ilta.domain.member.entity.Member;
 import com.ll.ilta.domain.member.repository.MemberRepository;
 import com.ll.ilta.global.payload.code.status.ErrorStatus;
@@ -38,7 +39,7 @@ public class MemberServiceImpl implements MemberService {
 
     @Transactional(readOnly = true)
     @Override
-    public boolean existsChildInfo(Long memberId) {
+    public boolean existsChild(Long memberId) {
         Member member = findMemberOrThrow(memberId);
         return member.getChildGrade() != null && member.getChildName() != null;
     }
@@ -54,11 +55,17 @@ public class MemberServiceImpl implements MemberService {
     public Member updateMyInfo(MemberRequestDTO.UpdateMemberDTO updateMemberDTO, Long memberId) {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new MemberHandler(ErrorStatus.NOT_FOUND_USER));
-        log.info(" MemberServiceImpl-updateMyInfo: Before update: memberId={}, currentNickname={}", memberId, member.getNickname());
-        log.info("MemberServiceImpl-updateMyInfo: UpdateMemberDTO nickname: {}", updateMemberDTO.getNickname());
 
-        member.updateMemberInfo(updateMemberDTO.getNickname());
-        log.info("MemberServiceImpl-updateMyInfo: After update: memberId={}, newNickname={}", memberId, member.getNickname());
+        member.updateMember(updateMemberDTO.getNickname());
+        return member;
+    }
+
+    @Override
+    public Member updateChild(ChildDTO childDTO, Long memberId) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new MemberHandler(ErrorStatus.NOT_FOUND_USER));
+
+        member.updateChild(childDTO);
         return member;
     }
 }

--- a/src/main/java/com/ll/ilta/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/ll/ilta/domain/member/service/MemberServiceImpl.java
@@ -1,8 +1,7 @@
 package com.ll.ilta.domain.member.service;
 
-
-import com.ll.ilta.domain.member.dto.MemberRequestDTO;
-import com.ll.ilta.domain.member.dto.MemberRequestDTO.ChildDTO;
+import com.ll.ilta.domain.member.dto.MemberRequestDTO.ChildRequestDTO;
+import com.ll.ilta.domain.member.dto.MemberRequestDTO.UpdateMemberDTO;
 import com.ll.ilta.domain.member.entity.Member;
 import com.ll.ilta.domain.member.repository.MemberRepository;
 import com.ll.ilta.global.payload.code.status.ErrorStatus;
@@ -22,8 +21,7 @@ public class MemberServiceImpl implements MemberService {
     private final MemberRepository memberRepository;
 
     private Member findMemberOrThrow(Long memberId) {
-        return memberRepository.findById(memberId)
-            .orElseThrow(() -> new MemberHandler(ErrorStatus.NOT_FOUND_USER));
+        return memberRepository.findById(memberId).orElseThrow(() -> new MemberHandler(ErrorStatus.NOT_FOUND_USER));
     }
 
     @Transactional(readOnly = true)
@@ -52,7 +50,7 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
-    public Member updateMyInfo(MemberRequestDTO.UpdateMemberDTO updateMemberDTO, Long memberId) {
+    public Member updateMyInfo(UpdateMemberDTO updateMemberDTO, Long memberId) {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new MemberHandler(ErrorStatus.NOT_FOUND_USER));
 
@@ -61,11 +59,11 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
-    public Member updateChild(ChildDTO childDTO, Long memberId) {
+    public Member updateChild(ChildRequestDTO childRequestDTO, Long memberId) {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new MemberHandler(ErrorStatus.NOT_FOUND_USER));
 
-        member.updateChild(childDTO);
+        member.updateChild(childRequestDTO.getChildName(), childRequestDTO.getChildGrade());
         return member;
     }
 }

--- a/src/main/java/com/ll/ilta/domain/problem/repository/ProblemConceptRepository.java
+++ b/src/main/java/com/ll/ilta/domain/problem/repository/ProblemConceptRepository.java
@@ -4,5 +4,6 @@ import com.ll.ilta.domain.problem.entity.ProblemConcept;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProblemConceptRepository extends JpaRepository<ProblemConcept, Long> {
+
     void deleteByProblemId(Long problemId);
 }

--- a/src/main/java/com/ll/ilta/domain/problem/repository/ProblemRepository.java
+++ b/src/main/java/com/ll/ilta/domain/problem/repository/ProblemRepository.java
@@ -6,5 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ProblemRepository extends JpaRepository<Problem, Long>, ProblemRepositoryCustom {
-    
+
 }

--- a/src/main/java/com/ll/ilta/domain/problem/repository/ProblemRepositoryImpl.java
+++ b/src/main/java/com/ll/ilta/domain/problem/repository/ProblemRepositoryImpl.java
@@ -1,11 +1,11 @@
 package com.ll.ilta.domain.problem.repository;
 
-import static com.ll.ilta.domain.favorite.entity.QFavorite.favorite;
 import static com.ll.ilta.domain.concept.entity.QConcept.concept;
+import static com.ll.ilta.domain.favorite.entity.QFavorite.favorite;
+import static com.ll.ilta.domain.image.entity.QImage.image;
 import static com.ll.ilta.domain.problem.entity.QProblem.problem;
 import static com.ll.ilta.domain.problem.entity.QProblemConcept.problemConcept;
 import static com.ll.ilta.domain.problem.entity.QProblemResult.problemResult;
-import static com.ll.ilta.domain.image.entity.QImage.image;
 
 import com.ll.ilta.domain.concept.dto.ConceptDto;
 import com.ll.ilta.domain.problem.dto.ProblemResponseDto;

--- a/src/main/java/com/ll/ilta/domain/problem/service/ProblemService.java
+++ b/src/main/java/com/ll/ilta/domain/problem/service/ProblemService.java
@@ -1,5 +1,8 @@
 package com.ll.ilta.domain.problem.service;
 
+import com.ll.ilta.domain.concept.dto.ConceptDto;
+import com.ll.ilta.domain.concept.entity.Concept;
+import com.ll.ilta.domain.concept.repository.ConceptRepository;
 import com.ll.ilta.domain.favorite.repository.FavoriteRepository;
 import com.ll.ilta.domain.image.client.AiFeignClient;
 import com.ll.ilta.domain.image.dto.AiResponseDto;
@@ -9,7 +12,6 @@ import com.ll.ilta.domain.image.repository.ImageRepository;
 import com.ll.ilta.domain.image.service.SupabaseUploader;
 import com.ll.ilta.domain.member.entity.Member;
 import com.ll.ilta.domain.member.service.MemberService;
-import com.ll.ilta.domain.concept.dto.ConceptDto;
 import com.ll.ilta.domain.problem.dto.ProblemResponseDto;
 import com.ll.ilta.domain.problem.entity.Problem;
 import com.ll.ilta.domain.problem.entity.ProblemConcept;
@@ -17,8 +19,6 @@ import com.ll.ilta.domain.problem.entity.ProblemResult;
 import com.ll.ilta.domain.problem.repository.ProblemConceptRepository;
 import com.ll.ilta.domain.problem.repository.ProblemRepository;
 import com.ll.ilta.domain.problem.repository.ProblemResultRepository;
-import com.ll.ilta.domain.concept.entity.Concept;
-import com.ll.ilta.domain.concept.repository.ConceptRepository;
 import com.ll.ilta.global.cursor.dto.CursorPaginatedResponseDto;
 import com.ll.ilta.global.cursor.service.CursorUtil;
 import java.util.List;

--- a/src/main/java/com/ll/ilta/global/config/CorsConfig.java
+++ b/src/main/java/com/ll/ilta/global/config/CorsConfig.java
@@ -12,7 +12,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class CorsConfig implements WebMvcConfigurer {
 
     @Bean
-    public static  CorsConfigurationSource apiConfigurationSource() {
+    public static CorsConfigurationSource apiConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowedOrigins(List.of("http://localhost:5173", "https://ilta.onrender.com"));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));

--- a/src/main/java/com/ll/ilta/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/ll/ilta/global/config/RestTemplateConfig.java
@@ -1,12 +1,11 @@
 package com.ll.ilta.global.config;
 
+import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.converter.FormHttpMessageConverter;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
-
-import java.util.List;
 
 @Configuration
 public class RestTemplateConfig {

--- a/src/main/java/com/ll/ilta/global/config/SwaggerConfig.java
+++ b/src/main/java/com/ll/ilta/global/config/SwaggerConfig.java
@@ -19,4 +19,5 @@ import org.springframework.context.annotation.Configuration;
     bearerFormat = "JWT"
 )
 public class SwaggerConfig {
+
 }

--- a/src/main/java/com/ll/ilta/global/payload/code/BaseCode.java
+++ b/src/main/java/com/ll/ilta/global/payload/code/BaseCode.java
@@ -1,6 +1,7 @@
 package com.ll.ilta.global.payload.code;
 
 public interface BaseCode {
+
     ReasonDTO getReason();
 
     ReasonDTO getReasonHttpStatus();

--- a/src/main/java/com/ll/ilta/global/payload/code/BaseErrorCode.java
+++ b/src/main/java/com/ll/ilta/global/payload/code/BaseErrorCode.java
@@ -1,6 +1,7 @@
 package com.ll.ilta.global.payload.code;
 
 public interface BaseErrorCode {
+
     ErrorReasonDTO getReason();
 
     ErrorReasonDTO getReasonHttpStatus();

--- a/src/main/java/com/ll/ilta/global/payload/code/ErrorReasonDTO.java
+++ b/src/main/java/com/ll/ilta/global/payload/code/ErrorReasonDTO.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @Builder
 public class ErrorReasonDTO {
+
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;

--- a/src/main/java/com/ll/ilta/global/payload/code/ReasonDTO.java
+++ b/src/main/java/com/ll/ilta/global/payload/code/ReasonDTO.java
@@ -7,8 +7,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 @Builder
 public class ReasonDTO {
-    private HttpStatus httpStatus;
+
     private final boolean isSuccess;
     private final String code;
     private final String message;
+    private HttpStatus httpStatus;
 }

--- a/src/main/java/com/ll/ilta/global/payload/exception/ExceptionAdvice.java
+++ b/src/main/java/com/ll/ilta/global/payload/exception/ExceptionAdvice.java
@@ -1,8 +1,8 @@
 package com.ll.ilta.global.payload.exception;
 
-import com.ll.ilta.global.payload.response.BaseResponse;
 import com.ll.ilta.global.payload.code.ErrorReasonDTO;
 import com.ll.ilta.global.payload.code.status.ErrorStatus;
+import com.ll.ilta.global.payload.response.BaseResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 import java.util.LinkedHashMap;

--- a/src/main/java/com/ll/ilta/global/payload/exception/handler/ProblemHandler.java
+++ b/src/main/java/com/ll/ilta/global/payload/exception/handler/ProblemHandler.java
@@ -3,7 +3,8 @@ package com.ll.ilta.global.payload.exception.handler;
 import com.ll.ilta.global.payload.code.BaseErrorCode;
 import com.ll.ilta.global.payload.exception.GeneralException;
 
-public class ProblemHandler extends GeneralException  {
+public class ProblemHandler extends GeneralException {
+
     public ProblemHandler(BaseErrorCode code) {
         super(code);
     }

--- a/src/main/java/com/ll/ilta/global/payload/exception/handler/TestHandler.java
+++ b/src/main/java/com/ll/ilta/global/payload/exception/handler/TestHandler.java
@@ -4,6 +4,7 @@ import com.ll.ilta.global.payload.code.BaseErrorCode;
 import com.ll.ilta.global.payload.exception.GeneralException;
 
 public class TestHandler extends GeneralException {
+
     public TestHandler(BaseErrorCode code) {
         super(code);
     }

--- a/src/main/java/com/ll/ilta/global/payload/response/BaseResponse.java
+++ b/src/main/java/com/ll/ilta/global/payload/response/BaseResponse.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.ll.ilta.global.payload.code.BaseCode;
-import com.ll.ilta.global.payload.code.status.SuccessStatus;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 

--- a/src/main/java/com/ll/ilta/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/ll/ilta/global/security/config/SecurityConfig.java
@@ -77,6 +77,8 @@ public class SecurityConfig {
             .requestMatchers(HttpMethod.GET, "/api/v2/members/me/profile").hasAnyRole("USER", "ADMIN")
             .requestMatchers(HttpMethod.PATCH, "/api/v2/members/me/profile").hasAnyRole("USER", "ADMIN")
             .requestMatchers(HttpMethod.DELETE, "/api/v2/members/me/profile").hasAnyRole("USER", "ADMIN")
+            .requestMatchers(HttpMethod.GET, "/api/v2/members/child/profile").hasAnyRole("USER", "ADMIN")
+            .requestMatchers(HttpMethod.PATCH, "/api/v2/members/child/profile").hasAnyRole("USER", "ADMIN")
             .requestMatchers(HttpMethod.GET, "/api/v2/members/me/child-info/exist").hasAnyRole("USER", "ADMIN")
 
             .requestMatchers(HttpMethod.POST, "/api/v2/members/{memberId}/posts").hasAnyRole("USER", "ADMIN")

--- a/src/main/java/com/ll/ilta/global/security/jwt/JwtUtil.java
+++ b/src/main/java/com/ll/ilta/global/security/jwt/JwtUtil.java
@@ -85,7 +85,8 @@ public class JwtUtil {
             //Date now = new Date();
             return expiredDate.after(new Date()); //now
         } catch (ExpiredJwtException e) {
-            log.warn("[JWT] 만료된 토큰 ❌ | 앞 10자리: {} | 에러: {}", token.substring(0, Math.min(10, token.length())), e.getMessage());
+            log.warn("[JWT] 만료된 토큰 ❌ | 앞 10자리: {} | 에러: {}", token.substring(0, Math.min(10, token.length())),
+                e.getMessage());
             log.info("[*] _AUTH_EXPIRE_TOKEN");
 
             throw new AuthHandler(ErrorStatus.AUTH_EXPIRE_TOKEN);
@@ -94,7 +95,8 @@ public class JwtUtil {
                  | IllegalArgumentException
                  | MalformedJwtException
                  | UnsupportedJwtException e) {
-            log.warn("[JWT] 유효하지 않은 토큰 ❌ | 앞 10자리: {} | 에러: {}", token.substring(0, Math.min(10, token.length())), e.getMessage());
+            log.warn("[JWT] 유효하지 않은 토큰 ❌ | 앞 10자리: {} | 에러: {}", token.substring(0, Math.min(10, token.length())),
+                e.getMessage());
             log.info("[*] AUTH_INVALID_TOKEN");
             throw new AuthHandler(ErrorStatus.AUTH_INVALID_TOKEN);
         }

--- a/src/main/java/com/ll/ilta/global/security/member/PrincipalDetails.java
+++ b/src/main/java/com/ll/ilta/global/security/member/PrincipalDetails.java
@@ -36,6 +36,7 @@ public class PrincipalDetails implements UserDetails {
     public String getPassword() {
         return null;
     }
+
     @Override
     public String getUsername() {
         return member.getEmail();

--- a/src/main/java/com/ll/ilta/global/security/member/PrincipalDetailsService.java
+++ b/src/main/java/com/ll/ilta/global/security/member/PrincipalDetailsService.java
@@ -11,7 +11,9 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class PrincipalDetailsService implements UserDetailsService {
+
     private final MemberRepository memberRepository;
+
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
         Member member = memberRepository.findByEmail(email)


### PR DESCRIPTION
## 📝작업 내용

### 자녀 정보 조회 및 수정
- 현재 기준, 한 회원 당 한 명의 자녀를 가짐
- 따라서, `memberId` 기준으로 조회하도록 함

### 회원 정보 조회에 `email` 추가
- 회원 정보 조회 시, 응답 dto에 email 추가

```
api/v2/child/profile
```

## PR 유형

- [x] 새로운 기능 추가
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
